### PR TITLE
🔨 refactor: 숲 초대 코드, 이메일 DB 저장 로직 구현 및 만료 스케줄링 추가

### DIFF
--- a/src/main/java/com/x1/groo/GrooApplication.java
+++ b/src/main/java/com/x1/groo/GrooApplication.java
@@ -2,7 +2,9 @@ package com.x1.groo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class GrooApplication {
 

--- a/src/main/java/com/x1/groo/common/exception/ErrorCode.java
+++ b/src/main/java/com/x1/groo/common/exception/ErrorCode.java
@@ -45,6 +45,9 @@ public enum ErrorCode {
     FOREST_FULL(HttpStatus.BAD_REQUEST, "F005", "이 숲은 이미 정원이 가득 찼습니다."),
     FOREST_INVITE_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "F006", "초대 코드를 생성하지 못했습니다."),
     FOREST_INVITE_CODE_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "F007", "초대 코드 저장 중 오류가 발생했습니다."),
+    FOREST_INVITE_CODE_REVOKED(HttpStatus.FORBIDDEN, "F008", "회수된 초대 코드입니다."),
+    FOREST_INVITE_CODE_USED(HttpStatus.CONFLICT, "F009", "이미 사용된 초대 코드입니다."),
+    FOREST_INVITE_CODE_EXPIRED(HttpStatus.GONE, "F010", "만료된 초대 코드입니다."),
 
     // forest 내 placement 관련
     PLACEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "배치된 아이템을 찾을 수 없습니다."),

--- a/src/main/java/com/x1/groo/common/exception/ErrorCode.java
+++ b/src/main/java/com/x1/groo/common/exception/ErrorCode.java
@@ -43,6 +43,8 @@ public enum ErrorCode {
     FOREST_INVITE_CODE_INVALID(HttpStatus.BAD_REQUEST, "F003", "초대코드가 유효하지 않습니다."),
     FOREST_ALREADY_ACCEPTED_INVITE(HttpStatus.BAD_REQUEST, "F004", "이미 숲에 참여한 사용자입니다."),
     FOREST_FULL(HttpStatus.BAD_REQUEST, "F005", "이 숲은 이미 정원이 가득 찼습니다."),
+    FOREST_INVITE_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "F006", "초대 코드를 생성하지 못했습니다."),
+    FOREST_INVITE_CODE_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "F007", "초대 코드 저장 중 오류가 발생했습니다."),
 
     // forest 내 placement 관련
     PLACEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "배치된 아이템을 찾을 수 없습니다."),

--- a/src/main/java/com/x1/groo/config/AppConfig.java
+++ b/src/main/java/com/x1/groo/config/AppConfig.java
@@ -10,7 +10,7 @@ import org.springframework.web.client.RestTemplate;
 @Configuration
 public class AppConfig {
 
-    /* 설명. ModelMapper가 매번 매핑할 때 정확히 일치하는 필드끼리 매칭하도록 설정한 bean */
+    /* ModelMapper가 매번 매핑할 때 정확히 일치하는 필드끼리 매칭하도록 설정한 bean */
     @Bean
     public ModelMapper modelMapper() {
         ModelMapper modelMapper = new ModelMapper();

--- a/src/main/java/com/x1/groo/diary/service/DiaryServiceImpl.java
+++ b/src/main/java/com/x1/groo/diary/service/DiaryServiceImpl.java
@@ -59,64 +59,27 @@ public class DiaryServiceImpl implements DiaryService {
         int forestId = req.getForestId();
         int categoryId = req.getCategoryId();
         LocalDateTime createdAt = req.getCreatedAt();
-
-
-        // 권한 체크
-        boolean owner = forestRepo.findById(forestId)
-                .map(f -> f.getUser().getId() == userId)
-                .orElse(false);
-        boolean shared = sharedForestRepo.existsByUserIdAndForestId(userId, forestId);
-        if (!(owner || shared)) {
-            throw new CustomException(ErrorCode.DIARY_ACCESS_DENIED);
-        }
-
-        ///   [실제 사용 기능   ///
-        // AI 감정 분석
-        EmotionResponseDTO aiRes = emotionService.analyzeEmotion(
-                new EmotionRequestDTO(req.getContent())
-        );
-        String mainEmotion = aiRes.getMainEmotion()
-                .trim()
-                .replaceAll("[\"\\r\\n]", "");
-
-        String weather = aiRes.getWeather();
-
-        // Diary 저장
-        Diary diary = new Diary();
-        diary.setContent(req.getContent());
-        diary.setIsPublished(true);
-        diary.setUserId(userId);
-        diary.setForestId(forestId);
-        diary.setWeather(weather);
-        diary.setCreatedAt(createdAt);
-        diary.setUpdatedAt(LocalDateTime.now());
-        Diary savedDiary = diaryRepo.save(diary);
-
-        // 상위 2개 감정 추출 및 저장
-        LinkedHashMap<String, Integer> top2 = aiRes.getEmotionResult().entrySet().stream()
-                .sorted((e1, e2) -> e2.getValue().compareTo(e1.getValue()))
-                .limit(2)
-                .collect(Collectors.toMap(
-                        Map.Entry::getKey,
-                        Map.Entry::getValue,
-                        (oldVal, newVal) -> oldVal,
-                        LinkedHashMap::new
-                ));
-        top2.forEach((emotion, weight) -> {
-            DiaryEmotion de = new DiaryEmotion();
-            de.setDiary(savedDiary);
-            de.setEmotion(emotion);
-            de.setWeight(weight);
-            emotionRepo.save(de);
-        });
-
-        List<CategoryEmotionItemDTO> emotionItems =
-          itemService.findItemsByCategoryAndEmotion(categoryId, mainEmotion);
-        ///   실제 사용 기능]   ///
-
-        ///   [테스트용 기능   /// OpenAPI 요금을 사용하지 않기 위함. 실제 사용 기능 부분을 주석처리 후 사용
-//        String weather = "맑음";
-//        String mainEmotion = "즐거움";
+//
+//
+//        // 권한 체크
+//        boolean owner = forestRepo.findById(forestId)
+//                .map(f -> f.getUser().getId() == userId)
+//                .orElse(false);
+//        boolean shared = sharedForestRepo.existsByUserIdAndForestId(userId, forestId);
+//        if (!(owner || shared)) {
+//            throw new CustomException(ErrorCode.DIARY_ACCESS_DENIED);
+//        }
+//
+//        ///   [실제 사용 기능   ///
+//        // AI 감정 분석
+//        EmotionResponseDTO aiRes = emotionService.analyzeEmotion(
+//                new EmotionRequestDTO(req.getContent())
+//        );
+//        String mainEmotion = aiRes.getMainEmotion()
+//                .trim()
+//                .replaceAll("[\"\\r\\n]", "");
+//
+//        String weather = aiRes.getWeather();
 //
 //        // Diary 저장
 //        Diary diary = new Diary();
@@ -129,10 +92,16 @@ public class DiaryServiceImpl implements DiaryService {
 //        diary.setUpdatedAt(LocalDateTime.now());
 //        Diary savedDiary = diaryRepo.save(diary);
 //
-//        LinkedHashMap<String, Integer> top2 = new LinkedHashMap<>();
-//        top2.put("즐거움", 60);
-//        top2.put("설렘", 40);
-//
+//        // 상위 2개 감정 추출 및 저장
+//        LinkedHashMap<String, Integer> top2 = aiRes.getEmotionResult().entrySet().stream()
+//                .sorted((e1, e2) -> e2.getValue().compareTo(e1.getValue()))
+//                .limit(2)
+//                .collect(Collectors.toMap(
+//                        Map.Entry::getKey,
+//                        Map.Entry::getValue,
+//                        (oldVal, newVal) -> oldVal,
+//                        LinkedHashMap::new
+//                ));
 //        top2.forEach((emotion, weight) -> {
 //            DiaryEmotion de = new DiaryEmotion();
 //            de.setDiary(savedDiary);
@@ -142,7 +111,38 @@ public class DiaryServiceImpl implements DiaryService {
 //        });
 //
 //        List<CategoryEmotionItemDTO> emotionItems =
-//                itemService.findItemsByCategoryAndEmotion(categoryId, mainEmotion);
+//          itemService.findItemsByCategoryAndEmotion(categoryId, mainEmotion);
+        ///   실제 사용 기능]   ///
+
+        ///   [테스트용 기능   /// OpenAPI 요금을 사용하지 않기 위함. 실제 사용 기능 부분을 주석처리 후 사용
+        String weather = "맑음";
+        String mainEmotion = "즐거움";
+
+        // Diary 저장
+        Diary diary = new Diary();
+        diary.setContent(req.getContent());
+        diary.setIsPublished(true);
+        diary.setUserId(userId);
+        diary.setForestId(forestId);
+        diary.setWeather(weather);
+        diary.setCreatedAt(createdAt);
+        diary.setUpdatedAt(LocalDateTime.now());
+        Diary savedDiary = diaryRepo.save(diary);
+
+        LinkedHashMap<String, Integer> top2 = new LinkedHashMap<>();
+        top2.put("즐거움", 60);
+        top2.put("설렘", 40);
+
+        top2.forEach((emotion, weight) -> {
+            DiaryEmotion de = new DiaryEmotion();
+            de.setDiary(savedDiary);
+            de.setEmotion(emotion);
+            de.setWeight(weight);
+            emotionRepo.save(de);
+        });
+
+        List<CategoryEmotionItemDTO> emotionItems =
+                itemService.findItemsByCategoryAndEmotion(categoryId, mainEmotion);
         ///   테스트용 기능]   ///
 
         return new DiaryResponseDTO(

--- a/src/main/java/com/x1/groo/email/aggregate/EmailEntity.java
+++ b/src/main/java/com/x1/groo/email/aggregate/EmailEntity.java
@@ -1,0 +1,42 @@
+package com.x1.groo.email.aggregate;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "email")
+public class EmailEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false, name = "verification_code")
+    private String verificationCode;
+
+    @Column(nullable = false, name = "is_verified")
+    private boolean isVerified = false;
+
+    @Column(nullable = false, name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "used_at")
+    private LocalDateTime usedAt;
+
+    @Column(nullable = false, name = "expires_at")
+    private LocalDateTime expiresAt;
+
+    @PrePersist
+    void prePersist() {
+        if(createdAt == null) createdAt = LocalDateTime.now();
+        if(expiresAt == null) expiresAt = createdAt.plusMinutes(5);
+    }
+}

--- a/src/main/java/com/x1/groo/email/aggregate/EmailEntity.java
+++ b/src/main/java/com/x1/groo/email/aggregate/EmailEntity.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 @Entity
-@Table(name = "email")
+@Table(name = "email_verification")
 public class EmailEntity {
 
     @Id

--- a/src/main/java/com/x1/groo/email/controller/EmailController.java
+++ b/src/main/java/com/x1/groo/email/controller/EmailController.java
@@ -33,6 +33,8 @@ public class EmailController {
     @Operation(summary = "인증 코드 일치 여부 확인")
     @PostMapping("/verification")
     public ResponseEntity<String> verifyEmail(@RequestBody @Valid EmailCheckDTO emailCheckDto) {
+
+        log.info("email: {}, auth: {}", emailCheckDto.getEmail(),emailCheckDto.getAuthNum());
         return userService.verifyEmailAuthentication(emailCheckDto);
     }
 }

--- a/src/main/java/com/x1/groo/email/repository/EmailRepository.java
+++ b/src/main/java/com/x1/groo/email/repository/EmailRepository.java
@@ -1,0 +1,12 @@
+package com.x1.groo.email.repository;
+
+import com.x1.groo.email.aggregate.EmailEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface EmailRepository extends JpaRepository<EmailEntity, Integer> {
+
+
+}

--- a/src/main/java/com/x1/groo/email/repository/EmailRepository.java
+++ b/src/main/java/com/x1/groo/email/repository/EmailRepository.java
@@ -1,12 +1,26 @@
 package com.x1.groo.email.repository;
 
 import com.x1.groo.email.aggregate.EmailEntity;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotEmpty;
+import org.apache.ibatis.annotations.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 
 @Repository
 public interface EmailRepository extends JpaRepository<EmailEntity, Integer> {
 
+    @Query("""
+        SELECT e
+          FROM EmailEntity e
+         WHERE e.email = :email
+           AND e.isVerified = false
+           AND e.expiresAt > CURRENT_TIMESTAMP
+         ORDER BY e.createdAt desc
+        """)
+//    String findByEmail(@Param("email")@Email @NotEmpty(message = "이메일을 입력해 주세요") String email);
 
+    EmailEntity findByEmail(@Param("email") String email);
 }

--- a/src/main/java/com/x1/groo/email/repository/EmailRepository.java
+++ b/src/main/java/com/x1/groo/email/repository/EmailRepository.java
@@ -1,12 +1,13 @@
 package com.x1.groo.email.repository;
 
 import com.x1.groo.email.aggregate.EmailEntity;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotEmpty;
 import org.apache.ibatis.annotations.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
 
 
 @Repository
@@ -20,7 +21,9 @@ public interface EmailRepository extends JpaRepository<EmailEntity, Integer> {
            AND e.expiresAt > CURRENT_TIMESTAMP
          ORDER BY e.createdAt desc
         """)
-//    String findByEmail(@Param("email")@Email @NotEmpty(message = "이메일을 입력해 주세요") String email);
-
     EmailEntity findByEmail(@Param("email") String email);
+
+    @Modifying
+    @Query("DELETE FROM EmailEntity e WHERE e.expiresAt < :cutoff AND e.isVerified = false")
+    int deleteExpired(@Param("cutoff") LocalDateTime cutoff);
 }

--- a/src/main/java/com/x1/groo/email/service/EmailServiceImpl.java
+++ b/src/main/java/com/x1/groo/email/service/EmailServiceImpl.java
@@ -2,7 +2,9 @@ package com.x1.groo.email.service;
 
 import com.x1.groo.common.exception.CustomException;
 import com.x1.groo.common.exception.ErrorCode;
+import com.x1.groo.email.aggregate.EmailEntity;
 import com.x1.groo.email.config.RedisUtil;
+import com.x1.groo.email.repository.EmailRepository;
 import com.x1.groo.user.service.UserService;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
@@ -10,6 +12,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Random;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
@@ -18,21 +23,16 @@ import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class EmailServiceImpl implements EmailService {
 
     private final JavaMailSender mailSender;
     private final RedisUtil redisUtil;
     private final UserService userService;
+    private final EmailRepository emailRepository;
 
     @Value("${spring.mail.auth-code-expiration-millis}")
     private long authCodeExpirationMillis;
-
-    @Autowired
-    public EmailServiceImpl(JavaMailSender mailSender, RedisUtil redisUtil, UserService userService) {
-        this.mailSender = mailSender;
-        this.redisUtil = redisUtil;
-        this.userService = userService;
-    }
 
     private int authNumber;
 
@@ -42,12 +42,16 @@ public class EmailServiceImpl implements EmailService {
         authNumber = r.nextInt(900000) + 100000; // 100000 ~ 999999
     }
 
+    @Transactional
     @Override
     public String joinEmail(String email) {
         makeRandomNumber();
         String setFrom = "\"Groo Admin\" <x1grooservice@gmail.com>";
-        String toMail = email;
         String title = "Groo 회원 가입 인증 이메일 입니다.";
+
+        EmailEntity entity = new EmailEntity();
+        entity.setEmail(email);
+        entity.setVerificationCode(String.valueOf(authNumber));
 
         try {
             // HTML 템플릿 로드
@@ -57,7 +61,9 @@ public class EmailServiceImpl implements EmailService {
             content = content.replace("${authNumber}", String.valueOf(authNumber));
 
             // 이메일 발송
-            mailSend(setFrom, toMail, title, content);
+            mailSend(setFrom, email, title, content);
+
+            emailRepository.save(entity);
 
             return Integer.toString(authNumber);
         } catch (IOException e) {

--- a/src/main/java/com/x1/groo/forest/common/domain/repository/ForestRepository.java
+++ b/src/main/java/com/x1/groo/forest/common/domain/repository/ForestRepository.java
@@ -19,4 +19,5 @@ public interface ForestRepository extends JpaRepository<ForestEntity, Integer> {
     @Query("select f.id from ForestEntity f where f.user.id = :userId order by 1 ASC \n" +
             "       limit 1")
     int findActiveForestIdByUserId(@Param("userId") int id);
+
 }

--- a/src/main/java/com/x1/groo/forest/mate/command/application/controller/CommandMateController.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/application/controller/CommandMateController.java
@@ -52,19 +52,17 @@ public class CommandMateController {
         int userId = user.getUserId();
         String inviteCode = commandMateService.createInviteLink(forestId, userId);
 
-        // 초대코드를 이용해서 최종 초대링크로 감싸기
         String inviteLink = "http://localhost:5173/mate/invite/" + inviteCode;
         return new CreateInviteRequest(inviteLink);
     }
 
     @Operation(summary = "초대 수락")
-    @PostMapping("/accept/{inviteCode}")
+    @PostMapping("/accept/{id}")
     public ResponseEntity<Map<String,Integer>> acceptInvite(@AuthenticationPrincipal CustomUserDetails user,
-                                               @PathVariable String inviteCode) {
+                                               @PathVariable int id) {
 
         int userId = user.getUserId();
-        int forestId = commandMateService.acceptInvite(userId, inviteCode);
-
+        int forestId = commandMateService.acceptInvite(userId, id);
 
         return ResponseEntity.ok(Map.of("forestId",forestId));
 

--- a/src/main/java/com/x1/groo/forest/mate/command/application/controller/CommandMateController.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/application/controller/CommandMateController.java
@@ -25,18 +25,15 @@ import java.util.Map;
 @Slf4j
 public class CommandMateController {
 
-    private final JwtUtil jwtUtil;
     private final CommandMateService commandMateService;
 
     @Autowired
-    public CommandMateController(JwtUtil jwtUtil, CommandMateService commandMateService) {
-        this.jwtUtil = jwtUtil;
+    public CommandMateController(CommandMateService commandMateService) {
         this.commandMateService = commandMateService;
     }
 
     @Operation(summary = "공유의 숲 탈퇴 및 숲 삭제", description = "숲의 정원이 0명일 경우 숲이 삭제됩니다.")
     @Transactional
-    // 공유의 숲 탈퇴 및 숲 삭제(0명이 되었을 때)
     @DeleteMapping("/quit")
     public ResponseEntity<String> quit(@AuthenticationPrincipal CustomUserDetails user,
                                        @RequestParam int forestId) {
@@ -49,10 +46,11 @@ public class CommandMateController {
 
     @Operation(summary = "초대 링크 생성")
     @GetMapping("/link")
-    public CreateInviteRequest createInviteLink(@RequestParam int forestId) {
+    public CreateInviteRequest createInviteLink(@RequestParam int forestId,
+                                                @AuthenticationPrincipal CustomUserDetails user) {
 
-        // 초대 링크 생성하고 결과 받기
-        String inviteCode = commandMateService.createInviteLink(forestId);
+        int userId = user.getUserId();
+        String inviteCode = commandMateService.createInviteLink(forestId, userId);
 
         // 초대코드를 이용해서 최종 초대링크로 감싸기
         String inviteLink = "http://localhost:5173/mate/invite/" + inviteCode;

--- a/src/main/java/com/x1/groo/forest/mate/command/application/controller/CommandMateController.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/application/controller/CommandMateController.java
@@ -57,12 +57,12 @@ public class CommandMateController {
     }
 
     @Operation(summary = "초대 수락")
-    @PostMapping("/accept/{id}")
+    @PostMapping("/accept/{inviteCode}")
     public ResponseEntity<Map<String,Integer>> acceptInvite(@AuthenticationPrincipal CustomUserDetails user,
-                                               @PathVariable int id) {
+                                               @PathVariable String inviteCode) {
 
         int userId = user.getUserId();
-        int forestId = commandMateService.acceptInvite(userId, id);
+        int forestId = commandMateService.acceptInvite(userId, inviteCode);
 
         return ResponseEntity.ok(Map.of("forestId",forestId));
 

--- a/src/main/java/com/x1/groo/forest/mate/command/application/scheduler/InviteCleanupScheduler.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/application/scheduler/InviteCleanupScheduler.java
@@ -1,0 +1,27 @@
+package com.x1.groo.forest.mate.command.application.scheduler;
+
+import com.x1.groo.forest.mate.command.domain.repository.ForestInviteRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class InviteCleanupScheduler {
+
+    private final ForestInviteRepository forestInviteRepository;
+
+    @Transactional
+    @Scheduled(cron = "0 5 * * * *", zone = "Asia/Seoul")
+    public void purge() {
+        LocalDateTime cutoff = LocalDateTime.now().minusDays(1); // 만료 1일 뒤 삭제
+        int purged = forestInviteRepository.deleteExpired(cutoff);
+        log.info("purged expired invites (cutoff={}): {}", cutoff, purged);
+
+    }
+}

--- a/src/main/java/com/x1/groo/forest/mate/command/application/scheduler/InviteCleanupScheduler.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/application/scheduler/InviteCleanupScheduler.java
@@ -1,5 +1,6 @@
 package com.x1.groo.forest.mate.command.application.scheduler;
 
+import com.x1.groo.email.repository.EmailRepository;
 import com.x1.groo.forest.mate.command.domain.repository.ForestInviteRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -15,13 +16,21 @@ import java.time.LocalDateTime;
 public class InviteCleanupScheduler {
 
     private final ForestInviteRepository forestInviteRepository;
+    private final EmailRepository emailRepository;
 
     @Transactional
-    @Scheduled(cron = "0 5 * * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 */15 * * * *", zone = "Asia/Seoul")
     public void purge() {
-        LocalDateTime cutoff = LocalDateTime.now().minusDays(1); // 만료 1일 뒤 삭제
-        int purged = forestInviteRepository.deleteExpired(cutoff);
-        log.info("purged expired invites (cutoff={}): {}", cutoff, purged);
+        LocalDateTime cutoff = LocalDateTime.now().minusMinutes(1);
+
+        // 초대코드 삭제
+        int forestInvitePurged = forestInviteRepository.deleteExpired(cutoff);
+
+        // 이메일 인증코드 삭제
+        int emailPurged = emailRepository.deleteExpired(cutoff);
+
+        log.info("purged expired invites (cutoff={}): {}", cutoff, forestInvitePurged);
+        log.info("purged expired email (cutoff={}): {}", cutoff, emailPurged);
 
     }
 }

--- a/src/main/java/com/x1/groo/forest/mate/command/application/service/CommandMateService.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/application/service/CommandMateService.java
@@ -5,7 +5,7 @@ import com.x1.groo.forest.mate.command.domain.vo.CreateMateForestRequest;
 public interface CommandMateService {
     String createInviteLink(int forestId, int userId);
 
-    int acceptInvite(int userId, String inviteCode);
+    int acceptInvite(int userId, int id);
 
     void quit(int userId, int forestId);
 

--- a/src/main/java/com/x1/groo/forest/mate/command/application/service/CommandMateService.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/application/service/CommandMateService.java
@@ -3,7 +3,7 @@ package com.x1.groo.forest.mate.command.application.service;
 import com.x1.groo.forest.mate.command.domain.vo.CreateMateForestRequest;
 
 public interface CommandMateService {
-    String createInviteLink(int forestId);
+    String createInviteLink(int forestId, int userId);
 
     int acceptInvite(int userId, String inviteCode);
 

--- a/src/main/java/com/x1/groo/forest/mate/command/application/service/CommandMateService.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/application/service/CommandMateService.java
@@ -5,7 +5,7 @@ import com.x1.groo.forest.mate.command.domain.vo.CreateMateForestRequest;
 public interface CommandMateService {
     String createInviteLink(int forestId, int userId);
 
-    int acceptInvite(int userId, int id);
+    int acceptInvite(int userId, String inviteCode);
 
     void quit(int userId, int forestId);
 

--- a/src/main/java/com/x1/groo/forest/mate/command/application/service/CommandMateServiceImpl.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/application/service/CommandMateServiceImpl.java
@@ -66,7 +66,7 @@ public class CommandMateServiceImpl implements CommandMateService {
         if(!forestRepository.existsById(forestId))throw new CustomException(ErrorCode.FOREST_NOT_FOUND);
 
         for(int i=0; i<3; i++) {
-            String inviteCode = UUID.randomUUID().toString().replace("-","").substring(0,16);
+            String inviteCode = UUID.randomUUID().toString().replace("-","").substring(0,8);
 
             ForestInviteEntity entity = new ForestInviteEntity();
             entity.setForestId(forestId);

--- a/src/main/java/com/x1/groo/forest/mate/command/application/service/CommandMateServiceImpl.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/application/service/CommandMateServiceImpl.java
@@ -90,11 +90,11 @@ public class CommandMateServiceImpl implements CommandMateService {
     // 초대 수락
     @Transactional
     @Override
-    public int acceptInvite(int userId, int id) {
+    public int acceptInvite(int userId, String inviteCode) {
 
 
-        ForestInviteEntity invite = forestInviteRepository.findById(id)
-                .orElseThrow(() -> new CustomException(ErrorCode.FOREST_INVITE_CODE_INVALID));
+        ForestInviteEntity invite = forestInviteRepository.findByCode(inviteCode);
+        if(invite == null) throw new CustomException(ErrorCode.FOREST_INVITE_CODE_INVALID);
 
         int forestId = invite.getForestId();
 
@@ -106,7 +106,7 @@ public class CommandMateServiceImpl implements CommandMateService {
             throw new CustomException(ErrorCode.FOREST_INVITE_CODE_EXPIRED);
 
         // 초대코드 동시 수락 방지
-        int updated = forestInviteRepository.consume(id);
+        int updated = forestInviteRepository.consume(inviteCode);
         if (updated != 1) {
             throw new CustomException(ErrorCode.FOREST_INVITE_CODE_INVALID);
         }

--- a/src/main/java/com/x1/groo/forest/mate/command/application/service/CommandMateServiceImpl.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/application/service/CommandMateServiceImpl.java
@@ -8,15 +8,17 @@ import com.x1.groo.forest.common.domain.aggregate.UserEntity;
 import com.x1.groo.forest.common.domain.repository.BackgroundRepository;
 import com.x1.groo.forest.common.domain.repository.ForestRepository;
 import com.x1.groo.forest.common.domain.repository.UserRepository;
+import com.x1.groo.forest.mate.command.domain.aggregate.ForestInviteEntity;
 import com.x1.groo.forest.mate.command.domain.aggregate.SharedForestEntity;
+import com.x1.groo.forest.mate.command.domain.repository.ForestInviteRepository;
 import com.x1.groo.forest.mate.command.domain.repository.SharedForestRepository;
 import com.x1.groo.forest.mate.command.domain.vo.CreateMateForestRequest;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
-import java.time.Duration;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;
@@ -32,8 +34,10 @@ public class CommandMateServiceImpl implements CommandMateService {
     private final ForestRepository forestRepository;
     private final UserRepository userRepository;
     private final BackgroundRepository backgroundRepository;
+    private final ForestInviteRepository forestInviteRepository;
 
     // 우정의 숲 탈퇴
+    @Transactional
     @Override
     public void quit(int userId, int forestId) {
         boolean isMember = sharedForestRepository.existsByUserIdAndForestId(userId, forestId);
@@ -52,23 +56,34 @@ public class CommandMateServiceImpl implements CommandMateService {
 
     }
 
+
     // 초대 링크 생성
+    @Transactional
     @Override
-    public String createInviteLink(int forestId) {
+    public String createInviteLink(int forestId, int userId) {
 
+        if(!forestRepository.existsById(forestId))throw new CustomException(ErrorCode.FOREST_NOT_FOUND);
 
-        // 초대 링크 생성 로직 작성
-        // UUID 기반 inviteCode 생성
-        String inviteCode = UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        for(int i=0; i<3; i++) {
+            String inviteCode = UUID.randomUUID().toString().replace("-","").substring(0,16);
 
-        // Redis에 저장
-        String redisKey = "invite:" + inviteCode;
-        String redisValue = String.valueOf(forestId);
+            ForestInviteEntity entity = new ForestInviteEntity();
+            entity.setForestId(forestId);
+            entity.setCode(inviteCode);
+            entity.setCreatedBy(userId);
+            try {
+                forestInviteRepository.saveAndFlush(entity);
+                return inviteCode;
+            } catch (DataIntegrityViolationException e) {
+                if(!isUniqueViolation(e)) throw new CustomException(ErrorCode.FOREST_INVITE_GENERATION_FAILED);
+            }
+        }
+        throw new CustomException(ErrorCode.FOREST_INVITE_CODE_SAVE_FAILED);
+    }
 
-        redisTemplate.opsForValue()
-                .set(redisKey, redisValue, Duration.ofHours(24));
-
-        return inviteCode;
+    public boolean isUniqueViolation(DataIntegrityViolationException e) {
+        String message = String.valueOf(e);
+        return message.contains("uk_code") || message.contains("Duplicate") || message.contains("UNIQUE");
     }
 
     // 초대 수락

--- a/src/main/java/com/x1/groo/forest/mate/command/application/service/CommandMateServiceImpl.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/application/service/CommandMateServiceImpl.java
@@ -20,16 +20,17 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;
+
+import static com.x1.groo.forest.mate.command.domain.aggregate.InviteCodeStatus.REVOKED;
+import static com.x1.groo.forest.mate.command.domain.aggregate.InviteCodeStatus.USED;
 
 @Service
 @RequiredArgsConstructor
 public class CommandMateServiceImpl implements CommandMateService {
 
-
-    // 문자열(String)로 key-value를 저장하는 간단한 템플릿
-    private final StringRedisTemplate redisTemplate;
     private final SharedForestRepository sharedForestRepository;
     private final ForestRepository forestRepository;
     private final UserRepository userRepository;
@@ -89,40 +90,40 @@ public class CommandMateServiceImpl implements CommandMateService {
     // 초대 수락
     @Transactional
     @Override
-    public int acceptInvite(int userId, String inviteCode) {
+    public int acceptInvite(int userId, int id) {
 
-        String redisKey = "invite:" + inviteCode;
-        String value = redisTemplate.opsForValue().get(redisKey);
 
-        if (value == null) {
+        ForestInviteEntity invite = forestInviteRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.FOREST_INVITE_CODE_INVALID));
+
+        int forestId = invite.getForestId();
+
+        if (invite.getStatus() == REVOKED)
+            throw new CustomException(ErrorCode.FOREST_INVITE_CODE_REVOKED);
+        if (invite.getStatus() == USED)
+            throw new CustomException(ErrorCode.FOREST_INVITE_CODE_USED);
+        if (LocalDateTime.now().isAfter(invite.getExpiresAt()))
+            throw new CustomException(ErrorCode.FOREST_INVITE_CODE_EXPIRED);
+
+        // 초대코드 동시 수락 방지
+        int updated = forestInviteRepository.consume(id);
+        if (updated != 1) {
             throw new CustomException(ErrorCode.FOREST_INVITE_CODE_INVALID);
         }
 
-        int forestId;
-        try {
-            forestId = Integer.parseInt(value);
-        } catch (NumberFormatException e) {
-            throw new CustomException(ErrorCode.FOREST_INVITE_CODE_INVALID);
-        }
-
-        // 1. 이미 수락했는지 검사
-        boolean alreadyJoined = sharedForestRepository.existsByUserIdAndForestId(userId, forestId);
-        if (alreadyJoined) {
+        // 정원은 Lock 걸고 카운트
+        if (sharedForestRepository.existsByUserIdAndForestId(userId, forestId)) {
             throw new CustomException(ErrorCode.FOREST_ALREADY_ACCEPTED_INVITE);
         }
 
-        // 2. 현재 공유숲 참여 인원이 4명 이상인지 검사
-        int currentMemberCount = sharedForestRepository.countByForestId(forestId);
-        if (currentMemberCount >= 4) {
+        int count = sharedForestRepository.countByForestIdForUpdate(forestId);
+        if (count >= 4) {
             throw new CustomException(ErrorCode.FOREST_FULL);
         }
 
-        // 3. 가입
+        // 가입
         SharedForestEntity sharedForest = new SharedForestEntity(userId, forestId);
         sharedForestRepository.save(sharedForest);
-
-        // 4. 초대코드 삭제
-        redisTemplate.delete(redisKey);
 
         return forestId;
 

--- a/src/main/java/com/x1/groo/forest/mate/command/domain/aggregate/ForestInviteEntity.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/domain/aggregate/ForestInviteEntity.java
@@ -1,0 +1,45 @@
+package com.x1.groo.forest.mate.command.domain.aggregate;
+
+import jakarta.persistence.*;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+import static com.x1.groo.forest.mate.command.domain.aggregate.InviteCodeStatus.ACTIVE;
+
+@Setter
+@Entity
+@Table(name = "forest_invite")
+public class ForestInviteEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @Column(nullable = false)
+    private String code;
+
+    @Column(nullable = false, name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false, name = "expires_at")
+    private LocalDateTime expiresAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private InviteCodeStatus status;
+
+    @Column(nullable = false, name = "created_by")
+    private int createdBy;
+
+    @Column(nullable = false, name = "forest_id")
+    private int forestId;
+
+    @PrePersist
+    void prePersist() {
+        if(createdAt == null) createdAt = LocalDateTime.now();
+        if(status == null) status = ACTIVE;
+        if(expiresAt == null) expiresAt = createdAt.plusHours(24L);
+    }
+
+}

--- a/src/main/java/com/x1/groo/forest/mate/command/domain/aggregate/ForestInviteEntity.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/domain/aggregate/ForestInviteEntity.java
@@ -24,6 +24,9 @@ public class ForestInviteEntity {
     @Column(nullable = false, name = "created_at")
     private LocalDateTime createdAt;
 
+    @Column(name = "used_at")
+    private LocalDateTime usedAt;
+
     @Column(nullable = false, name = "expires_at")
     private LocalDateTime expiresAt;
 

--- a/src/main/java/com/x1/groo/forest/mate/command/domain/aggregate/ForestInviteEntity.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/domain/aggregate/ForestInviteEntity.java
@@ -1,6 +1,7 @@
 package com.x1.groo.forest.mate.command.domain.aggregate;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
@@ -8,6 +9,7 @@ import java.time.LocalDateTime;
 import static com.x1.groo.forest.mate.command.domain.aggregate.InviteCodeStatus.ACTIVE;
 
 @Setter
+@Getter
 @Entity
 @Table(name = "forest_invite")
 public class ForestInviteEntity {

--- a/src/main/java/com/x1/groo/forest/mate/command/domain/aggregate/InviteCodeStatus.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/domain/aggregate/InviteCodeStatus.java
@@ -1,0 +1,12 @@
+package com.x1.groo.forest.mate.command.domain.aggregate;
+
+public enum InviteCodeStatus {
+    ACTIVE("ACTIVE"),
+    USED("USED"),
+    REVOKED("REVOKED");
+    private final String inviteCodeStatus;
+
+    InviteCodeStatus(String inviteCodeStatus) {
+        this.inviteCodeStatus = inviteCodeStatus;
+    }
+}

--- a/src/main/java/com/x1/groo/forest/mate/command/domain/repository/ForestInviteRepository.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/domain/repository/ForestInviteRepository.java
@@ -1,0 +1,7 @@
+package com.x1.groo.forest.mate.command.domain.repository;
+
+import com.x1.groo.forest.mate.command.domain.aggregate.ForestInviteEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ForestInviteRepository extends JpaRepository<ForestInviteEntity, Integer> {
+}

--- a/src/main/java/com/x1/groo/forest/mate/command/domain/repository/ForestInviteRepository.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/domain/repository/ForestInviteRepository.java
@@ -13,14 +13,17 @@ public interface ForestInviteRepository extends JpaRepository<ForestInviteEntity
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(value = """
     UPDATE forest_invite
-       SET status = 'USED'
-     WHERE id = :id
+       SET status = 'USED',
+           used_at = NOW()
+     WHERE code = :inviteCode
        AND status = 'ACTIVE'
        AND expires_at > NOW()
   """, nativeQuery = true)
-    int consume(@Param("id") int id);
+    int consume(@Param("inviteCode") String inviteCode);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM ForestInviteEntity f WHERE f.expiresAt < :cutoff")
     int deleteExpired(@Param("cutoff") LocalDateTime cutoff);
+
+    ForestInviteEntity findByCode(String inviteCode);
 }

--- a/src/main/java/com/x1/groo/forest/mate/command/domain/repository/ForestInviteRepository.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/domain/repository/ForestInviteRepository.java
@@ -1,7 +1,20 @@
 package com.x1.groo.forest.mate.command.domain.repository;
 
 import com.x1.groo.forest.mate.command.domain.aggregate.ForestInviteEntity;
+import org.apache.ibatis.annotations.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ForestInviteRepository extends JpaRepository<ForestInviteEntity, Integer> {
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(value = """
+    UPDATE forest_invite
+       SET status = 'USED'
+     WHERE id = :id
+       AND status = 'ACTIVE'
+       AND expires_at > NOW()
+  """, nativeQuery = true)
+    int consume(@Param("id") int id);
 }

--- a/src/main/java/com/x1/groo/forest/mate/command/domain/repository/ForestInviteRepository.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/domain/repository/ForestInviteRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
+
 public interface ForestInviteRepository extends JpaRepository<ForestInviteEntity, Integer> {
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
@@ -17,4 +19,8 @@ public interface ForestInviteRepository extends JpaRepository<ForestInviteEntity
        AND expires_at > NOW()
   """, nativeQuery = true)
     int consume(@Param("id") int id);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM ForestInviteEntity f WHERE f.expiresAt < :cutoff")
+    int deleteExpired(@Param("cutoff") LocalDateTime cutoff);
 }

--- a/src/main/java/com/x1/groo/forest/mate/command/domain/repository/ForestInviteRepository.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/domain/repository/ForestInviteRepository.java
@@ -5,9 +5,11 @@ import org.apache.ibatis.annotations.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 
+@Repository
 public interface ForestInviteRepository extends JpaRepository<ForestInviteEntity, Integer> {
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)

--- a/src/main/java/com/x1/groo/forest/mate/command/domain/repository/SharedForestRepository.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/domain/repository/SharedForestRepository.java
@@ -1,12 +1,22 @@
 package com.x1.groo.forest.mate.command.domain.repository;
 
 import com.x1.groo.forest.mate.command.domain.aggregate.SharedForestEntity;
+import jakarta.persistence.LockModeType;
+import org.apache.ibatis.annotations.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.security.core.parameters.P;
 
 public interface SharedForestRepository extends JpaRepository<SharedForestEntity, Integer> {
+
     boolean existsByUserIdAndForestId(int userId, int forestId);
 
     int countByForestId(int forestId);
 
     void deleteByUserIdAndForestId(int userId, int id);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select count(sf) from SharedForestEntity sf where sf.forestId = :forestId")
+    int countByForestIdForUpdate(@Param("forestId") int forestId);
 }

--- a/src/main/java/com/x1/groo/forest/mate/command/domain/repository/SharedForestRepository.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/domain/repository/SharedForestRepository.java
@@ -6,8 +6,9 @@ import org.apache.ibatis.annotations.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.security.core.parameters.P;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface SharedForestRepository extends JpaRepository<SharedForestEntity, Integer> {
 
     boolean existsByUserIdAndForestId(int userId, int forestId);

--- a/src/main/java/com/x1/groo/forest/mate/query/controller/MateController.java
+++ b/src/main/java/com/x1/groo/forest/mate/query/controller/MateController.java
@@ -16,6 +16,7 @@ import org.apache.ibatis.annotations.Param;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.time.LocalDate;
 import java.util.List;

--- a/src/main/java/com/x1/groo/user/controller/UserController.java
+++ b/src/main/java/com/x1/groo/user/controller/UserController.java
@@ -1,37 +1,25 @@
 package com.x1.groo.user.controller;
 
-import com.x1.groo.auth.command.application.aggregate.RefreshToken;
-import com.x1.groo.auth.command.domain.repository.RefreshTokenRepository;
 import com.x1.groo.auth.command.util.CookieUtil;
-import com.x1.groo.auth.command.util.HashUtil;
-import com.x1.groo.security.CustomUserDetails;
-import com.x1.groo.security.dto.TokenDTO;
 import com.x1.groo.security.util.JwtUtil;
 import com.x1.groo.security.vo.LoginRequestVO;
-import com.x1.groo.security.vo.LoginResponseVO;
 import com.x1.groo.user.dto.LoginDTO;
 import com.x1.groo.user.dto.LoginUserDTO;
 import com.x1.groo.user.dto.UserDTO;
 import com.x1.groo.user.service.UserService;
 import com.x1.groo.user.vo.ResponsefindUserVO;
 import com.x1.groo.user.vo.SignupRequestVO;
-import io.jsonwebtoken.Jwt;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
-import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.web.bind.annotation.*;
-
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Tag(name = "유저", description = "회원가입 및 로그인 기능을 제공합니다.")
 @Slf4j

--- a/src/main/java/com/x1/groo/user/service/UserService.java
+++ b/src/main/java/com/x1/groo/user/service/UserService.java
@@ -23,8 +23,6 @@ public interface UserService extends UserDetailsService {
 
     boolean isNicknameExists(String nickname);
 
-    boolean isEmailRegistered(String email);
-
     ResponseEntity<String> verifyEmailAuthentication(@Valid EmailCheckDTO emailCheckDto);
 
     UserDTO getUserById(String memNo);

--- a/src/main/java/com/x1/groo/user/service/UserServiceImpl.java
+++ b/src/main/java/com/x1/groo/user/service/UserServiceImpl.java
@@ -3,14 +3,17 @@ package com.x1.groo.user.service;
 import com.x1.groo.auth.command.application.aggregate.RefreshToken;
 import com.x1.groo.auth.command.domain.repository.RefreshTokenRepository;
 import com.x1.groo.auth.command.util.HashUtil;
+import com.x1.groo.email.aggregate.EmailEntity;
 import com.x1.groo.email.config.RedisUtil;
 import com.x1.groo.email.dto.EmailCheckDTO;
+import com.x1.groo.email.repository.EmailRepository;
 import com.x1.groo.forest.common.domain.repository.ForestRepository;
 
 import com.x1.groo.common.exception.CustomException;
 import com.x1.groo.common.exception.ErrorCode;
 import com.x1.groo.forest.emotion.command.application.service.CommandEmotionForestService;
 import com.x1.groo.forest.emotion.command.domain.vo.RequestCreateVO;
+import com.x1.groo.forest.mate.command.domain.repository.ForestInviteRepository;
 import com.x1.groo.security.CustomUserDetails;
 import com.x1.groo.security.util.JwtUtil;
 import com.x1.groo.security.vo.LoginRequestVO;
@@ -26,6 +29,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import jakarta.validation.Valid;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -42,6 +46,8 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static java.awt.SystemColor.info;
+
 @Service
 @Builder
 @Slf4j
@@ -55,12 +61,14 @@ public class UserServiceImpl implements UserService {
     private final JwtUtil jwtUtil;
     private final RefreshTokenRepository refreshTokenRepository;
     private final ForestRepository forestRepository;
+    private final EmailRepository emailRepository;
+    private final ForestInviteRepository forestInviteRepository;
 
     public UserServiceImpl(UserRepository userRepository, BCryptPasswordEncoder bCryptPasswordEncoder,
                            ModelMapper modelMapper, RedisUtil redisUtil, CommandEmotionForestService forestService,
                            JwtUtil jwtUtil,
                            RefreshTokenRepository refreshTokenRepository,
-                           ForestRepository forestRepository) {
+                           ForestRepository forestRepository, EmailRepository emailRepository, ForestInviteRepository forestInviteRepository) {
         this.userRepository = userRepository;
         this.bCryptPasswordEncoder = bCryptPasswordEncoder;
         this.modelMapper = modelMapper;
@@ -69,6 +77,8 @@ public class UserServiceImpl implements UserService {
         this.jwtUtil = jwtUtil;
         this.refreshTokenRepository = refreshTokenRepository;
         this.forestRepository = forestRepository;
+        this.emailRepository = emailRepository;
+        this.forestInviteRepository = forestInviteRepository;
     }
 
     // 기능 : 회원가입
@@ -121,24 +131,28 @@ public class UserServiceImpl implements UserService {
         return userRepository.existsByEmail(nickname);
     }
 
-    @Override
-    public boolean isEmailRegistered(String email) {
-        return userRepository.existsByEmail(email);
-    }
 
     @Override
     public ResponseEntity<String> verifyEmailAuthentication(EmailCheckDTO emailCheckDto) {
-        // 이메일 중복 확인
-        if (isEmailRegistered(emailCheckDto.getEmail())) {
+
+        String email = emailCheckDto.getEmail();
+
+        EmailEntity entity = emailRepository.findByEmail(email);
+
+        if (userRepository.existsByEmail(email)) {
             throw new CustomException(ErrorCode.USER_EMAIL_DUPLICATE);
         }
 
-        // 인증번호 직접 검증
-        String storedAuthNum = redisUtil.getData(emailCheckDto.getEmail());
-
+        String storedAuthNum = entity.getVerificationCode();
         if (storedAuthNum == null || !storedAuthNum.equals(emailCheckDto.getAuthNum())) {
             throw new CustomException(ErrorCode.USER_EMAIL_AUTH_FAILED);
         }
+
+
+        entity.setVerified(true);
+        entity.setUsedAt(LocalDateTime.now());
+
+        emailRepository.save(entity);
 
         return ResponseEntity.ok("인증 성공");
     }
@@ -147,32 +161,32 @@ public class UserServiceImpl implements UserService {
     @Override
     public LoginDTO login(LoginRequestVO req) {
 
-        // 1) 사용자 조회
+        //  사용자 조회
         UserEntity loginUser = userRepository.findByEmail(req.getEmail())
                 .orElseThrow(() ->
                         new BadCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다."));
 
-        // 2) 비밀번호 검증
+        //  비밀번호 검증
         if (!bCryptPasswordEncoder.matches(req.getPassword(), loginUser.getPassword())) {
             throw new BadCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다.");
         }
 
 
-        // 3) UserDTO로 변환 → CustomUserDetails 생성
-        UserDTO userDto = UserDTO.fromEntity(loginUser);   // ⚠️ fromEntity 에서 id 타입 주의(아래 참고)
+        //  UserDTO로 변환 → CustomUserDetails 생성
+        UserDTO userDto = UserDTO.fromEntity(loginUser);
         CustomUserDetails user = new CustomUserDetails(userDto);
 
 
-        // 4) 권한 문자열 목록 뽑기 ("ROLE_USER" 형태)
+        //  권한 문자열 목록 뽑기 ("ROLE_USER" 형태)
         List<String> roles = user.getAuthorities().stream()
                 .map(GrantedAuthority::getAuthority)
                 .collect(Collectors.toList()); // JDK 8~11 (16+면 .toList())
 
 
-        // 4) AT 발급 (짧은 만료, 예: 15분)
+        //  AT 발급
         String accessToken = jwtUtil.generateAccessToken(user.getUserId(),user.getName(), roles);
 
-        // 5) RT 발급 & 저장(회전) (긴 만료, 예: 14일)
+        //  RT 발급 & 저장
         String newRt = jwtUtil.generateRefreshToken(user.getUserId());
 
         Jws<Claims> jws = jwtUtil.parserClaimsJws(newRt);


### PR DESCRIPTION
## 🧩 이슈 번호 

- close #20 

## ✅ 작업 사항
<br>

> 숲 초대 코드 생성 및 삭제
- `forestInviteEntity` 클래스, `InviteCodeStatus` enum 추가
- inviteCode 충돌 시(unique) 최대 3회 재시도
- saveAndFlush로 즉시 제약 검증
- `@PrePersist`로 createdAt, status, expiresAt 기본값 보장
- 만료 후 **1분** 경과한 초대 코드 **15분**간격 스케줄링 삭제  
-  에러코드 추가 : `FOREST_INVITE_GENERATION_FAILED(500)`, `FOREST_INVITE_CODE_SAVE_FAILED(500)`


> 숲 초대 코드 수락
- `Lock`과 원자적 업데이트를 이용한 동시 초대 수락 제어 추가
- 에러코드 추가 : `FOREST_INVITE_CODE_REVOKED(403)`, `FOREST_INVITE_CODE_USED(409)`, `FOREST_INVITE_CODE_EXPIRED(410)`

> 이메일 생성 · 승인 · 삭제
- `EmailEntity`클래스 추가
- 만료 후 **1분** 경과한 이메일 인증코드 **15분**간격 스케줄링 삭제 


## 👩‍💻 공유 포인트 및 논의 사항
