### PR TITLE
🌟 feat: 임시저장 조회 시 id, 내용, 날짜 반환

### DIFF
--- a/src/main/java/com/x1/groo/diary/controller/DiaryDraftController.java
+++ b/src/main/java/com/x1/groo/diary/controller/DiaryDraftController.java
@@ -1,5 +1,6 @@
 package com.x1.groo.diary.controller;
 
+import com.x1.groo.diary.dto.DiaryDraftInfoResponseDTO;
 import com.x1.groo.diary.dto.DiaryDraftListResponseDTO;
 import com.x1.groo.diary.dto.DiaryDraftRequestDTO;
 import com.x1.groo.diary.dto.DiaryDraftUpdateRequestDTO;
@@ -26,13 +27,13 @@ public class DiaryDraftController {
 
     @Operation(summary = "해당 날짜 일기 임시 저장 여부")
     @GetMapping("/{date}")
-    public ResponseEntity<Boolean> isDraftExist(
+    public ResponseEntity<DiaryDraftInfoResponseDTO> isDraftExist(
             @AuthenticationPrincipal CustomUserDetails user,
             @PathVariable @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
             ) {
-        boolean exists = diaryDraftService.existsDraftByDate(user.getUserId(), date);
+        DiaryDraftInfoResponseDTO draft = diaryDraftService.existsDraftByDate(user.getUserId(), date);
 
-        return ResponseEntity.ok(exists);
+        return ResponseEntity.ok(draft);
     }
 
     @Operation(summary = "총 임시 저장 개수 반환")

--- a/src/main/java/com/x1/groo/diary/dto/DiaryDraftInfoResponseDTO.java
+++ b/src/main/java/com/x1/groo/diary/dto/DiaryDraftInfoResponseDTO.java
@@ -1,0 +1,16 @@
+package com.x1.groo.diary.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@AllArgsConstructor
+@Getter
+@Setter
+public class DiaryDraftInfoResponseDTO {
+    private Integer draftId;
+    private String content;
+    private LocalDate diaryDate;
+}

--- a/src/main/java/com/x1/groo/diary/dto/DiaryDraftInfoResponseDTO.java
+++ b/src/main/java/com/x1/groo/diary/dto/DiaryDraftInfoResponseDTO.java
@@ -8,7 +8,6 @@ import java.time.LocalDate;
 
 @AllArgsConstructor
 @Getter
-@Setter
 public class DiaryDraftInfoResponseDTO {
     private Integer draftId;
     private String content;

--- a/src/main/java/com/x1/groo/diary/dto/DiaryDraftInfoResponseDTO.java
+++ b/src/main/java/com/x1/groo/diary/dto/DiaryDraftInfoResponseDTO.java
@@ -2,7 +2,6 @@ package com.x1.groo.diary.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
 
 import java.time.LocalDate;
 

--- a/src/main/java/com/x1/groo/diary/repository/DiaryDraftRepository.java
+++ b/src/main/java/com/x1/groo/diary/repository/DiaryDraftRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface DiaryDraftRepository extends JpaRepository<DiaryDraft, Integer> {
-    boolean existsByUserIdAndDiaryDate(int userId, LocalDate date);
+    Optional<DiaryDraft> findIdByUserIdAndDiaryDate(@Param("userId") int userId, @Param("date") LocalDate date);
 
     int countByUserId(int userId);
 

--- a/src/main/java/com/x1/groo/diary/repository/DiaryDraftRepository.java
+++ b/src/main/java/com/x1/groo/diary/repository/DiaryDraftRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface DiaryDraftRepository extends JpaRepository<DiaryDraft, Integer> {
-    Optional<DiaryDraft> findIdByUserIdAndDiaryDate(@Param("userId") int userId, @Param("date") LocalDate date);
+    Optional<DiaryDraft> findByUserIdAndDiaryDate(@Param("userId") int userId, @Param("date") LocalDate date);
 
     int countByUserId(int userId);
 

--- a/src/main/java/com/x1/groo/diary/service/DiaryDraftService.java
+++ b/src/main/java/com/x1/groo/diary/service/DiaryDraftService.java
@@ -1,5 +1,6 @@
 package com.x1.groo.diary.service;
 
+import com.x1.groo.diary.dto.DiaryDraftInfoResponseDTO;
 import com.x1.groo.diary.dto.DiaryDraftListResponseDTO;
 import com.x1.groo.diary.dto.DiaryDraftRequestDTO;
 import com.x1.groo.diary.dto.DiaryDraftUpdateRequestDTO;
@@ -8,7 +9,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface DiaryDraftService {
-    boolean existsDraftByDate(int userId, LocalDate date);
+    DiaryDraftInfoResponseDTO existsDraftByDate(int userId, LocalDate date);
 
     int getTotalDraftCount(int userId);
 

--- a/src/main/java/com/x1/groo/diary/service/DiaryDraftServiceImpl.java
+++ b/src/main/java/com/x1/groo/diary/service/DiaryDraftServiceImpl.java
@@ -2,6 +2,7 @@ package com.x1.groo.diary.service;
 
 import com.x1.groo.common.exception.CustomException;
 import com.x1.groo.common.exception.ErrorCode;
+import com.x1.groo.diary.dto.DiaryDraftInfoResponseDTO;
 import com.x1.groo.diary.dto.DiaryDraftListResponseDTO;
 import com.x1.groo.diary.dto.DiaryDraftRequestDTO;
 import com.x1.groo.diary.dto.DiaryDraftUpdateRequestDTO;
@@ -22,8 +23,13 @@ public class DiaryDraftServiceImpl implements DiaryDraftService {
 
     @Override
     @Transactional
-    public boolean existsDraftByDate(int userId, LocalDate date) {
-        return diaryDraftRepository.existsByUserIdAndDiaryDate(userId, date);
+    public DiaryDraftInfoResponseDTO existsDraftByDate(int userId, LocalDate date) {
+        return diaryDraftRepository.findIdByUserIdAndDiaryDate(userId, date)
+                .map(d -> new DiaryDraftInfoResponseDTO(
+                        d.getId(),
+                        d.getContent(),
+                        d.getDiaryDate()
+                )).orElse(new DiaryDraftInfoResponseDTO(null, null, null));
     }
 
     @Override

--- a/src/main/java/com/x1/groo/diary/service/DiaryDraftServiceImpl.java
+++ b/src/main/java/com/x1/groo/diary/service/DiaryDraftServiceImpl.java
@@ -24,7 +24,7 @@ public class DiaryDraftServiceImpl implements DiaryDraftService {
     @Override
     @Transactional
     public DiaryDraftInfoResponseDTO existsDraftByDate(int userId, LocalDate date) {
-        return diaryDraftRepository.findIdByUserIdAndDiaryDate(userId, date)
+        return diaryDraftRepository.findByUserIdAndDiaryDate(userId, date)
                 .map(d -> new DiaryDraftInfoResponseDTO(
                         d.getId(),
                         d.getContent(),


### PR DESCRIPTION
## ✅ 작업 사항
<br>

기존 boolean만 반환하던 임시 저장 존재 여부를 클라이언트에서 시각화하기 위해
api를 아이디, 내용, 날짜를 반환하게 바꿨습니다.

## 📸 스크린샷 (선택)
<br>

## 👩‍💻 공유 포인트 및 논의 사항
