### PR TITLE
🔨 refactor: 일기 상세 조회 응답 시간 개선

### DIFF
--- a/src/main/resources/com/x1/groo/forest/emotion/query/repository/QueryForestEmotionMapper.xml
+++ b/src/main/resources/com/x1/groo/forest/emotion/query/repository/QueryForestEmotionMapper.xml
@@ -64,7 +64,9 @@
         <id property="diaryId" column="diary_id"/>
         <result property="content" column="content"/>
         <result property="createdAt" column="created_at"/>
-        <collection property="emotions" ofType="string" column="diary_id" select="findEmotionsByDiaryId"/>
+        <collection property="emotions" ofType="string">
+            <result column="emotion_name" />
+        </collection>
     </resultMap>
 
     <resultMap id="DiaryByMonthResultMap" type="com.x1.groo.forest.emotion.query.dto.QueryForestEmotionDiaryByMonthDTO">
@@ -165,16 +167,19 @@
     </select>
 
     <select id="findDiaryByDateAndForestId" resultMap="DiaryWithEmotionResultMap">
-        SELECT DISTINCT
-            d.id AS diary_id
-                      , d.content
-                      , d.created_at
-        FROM diary d
-                 JOIN user u ON d.user_id = u.id
-                 JOIN forest f ON d.forest_id = f.id
-                 LEFT JOIN shared_forest sf ON f.id = sf.forest_id
-        WHERE f.id = #{forestId}
-          AND d.created_at BETWEEN #{startDateTime} AND #{endDateTime}
+        SELECT
+               d.id AS diary_id
+             , d.content
+             , d.created_at
+             , de.emotion AS emotion_name
+          FROM diary d
+          JOIN user u ON d.user_id = u.id
+          JOIN forest f ON d.forest_id = f.id
+          LEFT JOIN shared_forest sf ON f.id = sf.forest_id
+          LEFT JOIN diary_emotion de ON d.id = de.diary_id
+         WHERE f.id = #{forestId}
+           AND d.created_at BETWEEN #{startDateTime} AND #{endDateTime}
+         ORDER BY d.id DESC
     </select>
 
     <select id="findDiariesByMonth" resultMap="DiaryByMonthResultMap">
@@ -198,11 +203,4 @@
         WHERE user_id = #{userId}
           AND forest_id = #{forestId}
     </select>
-
-    <select id="findEmotionsByDiaryId" resultType="string">
-        SELECT emotion
-        FROM diary_emotion
-        WHERE diary_id = #{diary_id}
-    </select>
-
 </mapper>


### PR DESCRIPTION
## ✅ 작업 사항
<br>
기존 DB를 두 번 조회하는 쿼리를 한 번만 조회하게 변경<br>
DISTINCT 제거<br><br>
평균 응답 시간 29ms -> 24ms로 개선했습니다.

## 📸 스크린샷 (선택)
<br>

<img width="492" height="21" alt="diary date before" src="https://github.com/user-attachments/assets/ee5a26d9-606f-4a8e-a02b-482fecc357e4" />

<img width="499" height="22" alt="diary date after" src="https://github.com/user-attachments/assets/8939479a-a071-4e79-a9d0-dc52710aeaee" />


## 👩‍💻 공유 포인트 및 논의 사항
